### PR TITLE
CI-472 - Allow cache for shared dataset creds

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -16,7 +16,7 @@
         },
         "additionalProperties": {
           "npmName": "@cirrobio/api-client",
-          "npmVersion": "0.2.6",
+          "npmVersion": "0.2.7",
           "author": "CirroBio",
           "stringEnums": true
         }

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/api-client",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "API client for Cirro",
   "author": "CirroBio",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/sdk",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "SDK for Cirro",
   "author": "CirroBio",
   "repository": {


### PR DESCRIPTION
Allow cache for shared dataset credentials as well, but use a different cache key.