### PR TITLE
Re-add missing PortalErrorHandler export

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -16,7 +16,7 @@
         },
         "additionalProperties": {
           "npmName": "@cirrobio/api-client",
-          "npmVersion": "0.9.1",
+          "npmVersion": "0.9.2",
           "author": "CirroBio",
           "stringEnums": true,
           "supportsES6": true

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -36,7 +36,7 @@ navigate to the folder of your consuming project and run one of the following co
 _published:_
 
 ```
-npm install @cirrobio/api-client@0.9.1 --save
+npm install @cirrobio/api-client@0.9.2 --save
 ```
 
 _unPublished (not recommended):_

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/api-client",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "API client for Cirro",
   "author": "CirroBio",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "SDK for Cirro",
   "author": "CirroBio",
   "repository": {

--- a/packages/sdk/src/api.ts
+++ b/packages/sdk/src/api.ts
@@ -1,2 +1,3 @@
 export { ApiError } from './api/error';
+export { PortalErrorHandler } from './api/error-handler';
 export { generateApiConfig } from './api/config';


### PR DESCRIPTION
Somewhere in the refactor, the export line for `PortalErrorHandler` got deleted and needs to be re-added as its causing the portal to not load

Bump version for release