### PR TITLE
CI-739 - Specify CRC64 checksum when uploading S3 files

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -16,7 +16,7 @@
         },
         "additionalProperties": {
           "npmName": "@cirrobio/api-client",
-          "npmVersion": "0.10.1",
+          "npmVersion": "0.10.2",
           "author": "CirroBio",
           "stringEnums": true,
           "supportsES6": true

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -36,7 +36,7 @@ navigate to the folder of your consuming project and run one of the following co
 _published:_
 
 ```
-npm install @cirrobio/api-client@0.10.1 --save
+npm install @cirrobio/api-client@0.10.2 --save
 ```
 
 _unPublished (not recommended):_

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/api-client",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "API client for Cirro",
   "author": "CirroBio",
   "repository": {

--- a/packages/api-client/src/models/FileNamePattern.ts
+++ b/packages/api-client/src/models/FileNamePattern.ts
@@ -30,7 +30,7 @@ export interface FileNamePattern {
      * @type {string}
      * @memberof FileNamePattern
      */
-    description: string;
+    description?: string | null;
     /**
      * File name pattern, formatted as a valid regex, to extract sample name and other metadata.
      * @type {string}
@@ -45,7 +45,6 @@ export interface FileNamePattern {
 export function instanceOfFileNamePattern(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "exampleName" in value;
-    isInstance = isInstance && "description" in value;
     isInstance = isInstance && "sampleMatchingPattern" in value;
 
     return isInstance;
@@ -62,7 +61,7 @@ export function FileNamePatternFromJSONTyped(json: any, ignoreDiscriminator: boo
     return {
         
         'exampleName': json['exampleName'],
-        'description': json['description'],
+        'description': !exists(json, 'description') ? undefined : json['description'],
         'sampleMatchingPattern': json['sampleMatchingPattern'],
     };
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/sdk",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "SDK for Cirro",
   "author": "CirroBio",
   "repository": {

--- a/packages/sdk/src/file/actions/upload.fn.ts
+++ b/packages/sdk/src/file/actions/upload.fn.ts
@@ -1,6 +1,7 @@
 import { Upload } from "@aws-sdk/lib-storage";
 import { AWSCredentials } from '@cirrobio/api-client';
 import { createS3Client } from "../util/s3-client";
+import { PutObjectCommandInput } from "@aws-sdk/client-s3";
 
 export interface UploadFileParams {
   bucket: string;
@@ -14,12 +15,13 @@ export interface UploadFileParams {
  * Upload a file to S3
  */
 export function uploadFile({ bucket, path, file, credentials, metadata }: UploadFileParams): Upload {
-  const params = {
+  const params: PutObjectCommandInput = {
     Bucket: bucket,
     Key: path,
     Body: file,
     ContentType: file.type,
     Metadata: metadata,
+    ChecksumAlgorithm: 'CRC64NVME'
   };
   return new Upload({
     client: createS3Client(credentials),


### PR DESCRIPTION
CI-739

CRC64 checksum is the only one that works with full object. Specify this when uploading so we can pull it in https://github.com/CirroBio/Cirro-client/pull/161