### PR TITLE
CI-1208 - Modify to allow OIDC npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Build packages
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   release:
@@ -20,13 +21,13 @@ jobs:
         node-version: [20.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
@@ -41,8 +42,6 @@ jobs:
         if: github.event_name == 'release'
         working-directory: packages/api-client
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   build-sdk:
     runs-on: ubuntu-latest
@@ -52,13 +51,13 @@ jobs:
         node-version: [20.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
@@ -72,5 +71,3 @@ jobs:
         if: github.event_name == 'release'
         working-directory: packages/sdk
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Updated GitHub Actions workflow to use newer action versions and removed NODE_AUTH_TOKEN environment variable since OIDC publishing will be used.