### PR TITLE
CI-1331: Preserve visualization tool state via URL query param

### DIFF
--- a/packages/react-tool/package.json
+++ b/packages/react-tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/react-tool",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "React components and utilities for developing Cirro tools",
   "author": "CirroBio",
   "repository": {

--- a/packages/react-tool/src/models/message.ts
+++ b/packages/react-tool/src/models/message.ts
@@ -10,4 +10,5 @@ export interface ViewerConfigPayload {
   dataset: Partial<DatasetDetail>;
   manifest?: DatasetAssetsManifest;
   file?: string; // path relative to manifest domain
+  state?: string; // opaque tool state persisted by the portal
 }

--- a/packages/react-tool/src/viewer-context/tool-viewer-state.ts
+++ b/packages/react-tool/src/viewer-context/tool-viewer-state.ts
@@ -12,6 +12,8 @@ export class ToolViewerState implements ViewerState {
     readonly files: Assets,
     readonly fileAccessContext: ProjectFileAccessContext,
     readonly _selectedFile?: string | null,
+    readonly toolState?: string,
+    readonly sendStateUpdate: (state: string) => void = () => {},
   ) {
     if (_selectedFile && manifest) {
       this.selectedFile = {

--- a/packages/react-tool/src/viewer-context/viewer-context-provider.tsx
+++ b/packages/react-tool/src/viewer-context/viewer-context-provider.tsx
@@ -58,8 +58,13 @@ export function ViewerContextProvider({ children }): ReactElement {
   }, [manifest, fileAccessContext]);
 
   const state: ViewerState = useMemo(() => {
-    return new ToolViewerState(project, dataset, manifest, assets, fileAccessContext, viewerState.config?.file)
-  }, [dataService, project, dataset, manifest, viewerState.config?.file]);
+    return new ToolViewerState(
+      project, dataset, manifest, assets, fileAccessContext,
+      viewerState.config?.file,
+      viewerState.config?.state,
+      viewerState.sendStateUpdate,
+    )
+  }, [dataService, project, dataset, manifest, viewerState.config?.file, viewerState.config?.state, viewerState.sendStateUpdate]);
 
   const services: ViewerServices = { dataService, fileService };
   const value = useMemo(() => ({ state, services }), [state, services]);

--- a/packages/react-tool/src/viewer-context/viewer-state.ts
+++ b/packages/react-tool/src/viewer-context/viewer-state.ts
@@ -45,4 +45,16 @@ export interface ViewerState {
    * File access context, used to get any arbitrary file from the project.
    */
   fileAccessContext: ProjectFileAccessContext;
+
+  /**
+   * Opaque tool state string persisted by the portal across sessions.
+   * Restore UI state from this on load.
+   */
+  toolState?: string;
+
+  /**
+   * Send an opaque state string to the portal for persistence.
+   * Call this whenever the tool's shareable state changes.
+   */
+  sendStateUpdate: (state: string) => void;
 }

--- a/packages/react-tool/src/viewer-state/viewer-state-context.tsx
+++ b/packages/react-tool/src/viewer-state/viewer-state-context.tsx
@@ -10,6 +10,7 @@ export interface ViewerStateContextType {
   s3Credentials: AWSCredentials | null;
   updateConfig: (config: ViewerConfigPayload) => void;
   patchFetch: boolean;
+  sendStateUpdate: (state: string) => void;
 }
 
 export const ViewerStateContext = createContext<ViewerStateContextType | undefined>(undefined);

--- a/packages/react-tool/src/viewer-state/viewer-state-provider.tsx
+++ b/packages/react-tool/src/viewer-state/viewer-state-provider.tsx
@@ -57,8 +57,12 @@ export const ViewerStateProvider = ({ children, mode, patchFetch }: ViewerStateP
     setViewerConfig(config);
   }
 
+  const sendStateUpdate = (state: string) => {
+    window.parent.postMessage({ source: 'cirro-tool', payload: { type: 'STATE_UPDATE', state } });
+  };
+
   const value = useMemo(() => ({
-    status: viewerStatus, config: viewerConfig, s3Credentials, updateConfig, patchFetch
+    status: viewerStatus, config: viewerConfig, s3Credentials, updateConfig, patchFetch, sendStateUpdate
   }), [viewerStatus, viewerConfig]);
 
   return (


### PR DESCRIPTION
When developing visualization applications, it is helpful to be able to store the state in a way that can be restored if the user copies a URL. This is a minimal change that allows me to develop visualization applications with that behavior.