### PR TITLE
CI-1343 - Add markdown file extensions to array of files to be opened

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -22,7 +22,7 @@
         },
         "additionalProperties": {
           "npmName": "@cirrobio/api-client",
-          "npmVersion": "0.13.11",
+          "npmVersion": "0.13.12",
           "author": "CirroBio",
           "stringEnums": true,
           "supportsES6": true

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -36,7 +36,7 @@ navigate to the folder of your consuming project and run one of the following co
 _published:_
 
 ```
-npm install @cirrobio/api-client@0.13.11 --save
+npm install @cirrobio/api-client@0.13.12 --save
 ```
 
 _unPublished (not recommended):_

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/api-client",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "description": "API client for Cirro",
   "author": "CirroBio",
   "repository": {

--- a/packages/api-client/src/models/ProcessDocumentation.ts
+++ b/packages/api-client/src/models/ProcessDocumentation.ts
@@ -24,19 +24,19 @@ export interface ProcessDocumentation {
      * @type {string}
      * @memberof ProcessDocumentation
      */
-    docsUri?: string;
+    docsUri?: string | null;
     /**
-     * URI of process documentation (partial)
+     * URI of process documentation (partial) - only for Cirro-hosted docs
      * @type {string}
      * @memberof ProcessDocumentation
      */
-    partialUri?: string;
+    partialUri?: string | null;
     /**
      * Documentation content
      * @type {string}
      * @memberof ProcessDocumentation
      */
-    content?: string;
+    content?: string | null;
 }
 
 /**

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/sdk",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "description": "SDK for Cirro",
   "author": "CirroBio",
   "repository": {

--- a/packages/sdk/src/file/extensions.fn.ts
+++ b/packages/sdk/src/file/extensions.fn.ts
@@ -55,6 +55,11 @@ export const FILE_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'svg'];
 export const FILE_OME_EXTENSIONS = ['tif', 'ome.tif', 'ome.tiff', 'ome.tif.gz', 'ome.tiff.gz'];
 
 /**
+ * An array of file extensions that are rendered as formatted Markdown.
+ */
+export const FILE_MARKDOWN_EXTENSIONS = ['md', 'markdown'];
+
+/**
  * An array of file extensions that can be opened in the browser.
  * Includes common document formats such as HTML, PDF, and JSON, as well as image, DSV, TXT, and OME file formats.
  */
@@ -62,7 +67,8 @@ export const FILE_EXTENSIONS_TO_OPEN = ['html', 'pdf', 'json', 'fcs',
     ...FILE_IMAGE_EXTENSIONS,
     ...FILE_TXT_EXTENSIONS,
     ...FILE_TRACK_EXTENSIONS,
-    ...FILE_PROTEIN_STRUCTURE_EXTENSIONS
+    ...FILE_PROTEIN_STRUCTURE_EXTENSIONS,
+    ...FILE_MARKDOWN_EXTENSIONS
 ];
 
 


### PR DESCRIPTION
Added 'md' and 'markdown' file extension array to be used by portal code now that these files have a dedicated viewer.