### PR TITLE
Bump to v0.13.25 for new release.

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -22,7 +22,7 @@
         },
         "additionalProperties": {
           "npmName": "@cirrobio/api-client",
-          "npmVersion": "0.13.24",
+          "npmVersion": "0.13.25",
           "author": "CirroBio",
           "stringEnums": true,
           "supportsES6": true

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -36,7 +36,7 @@ navigate to the folder of your consuming project and run one of the following co
 _published:_
 
 ```
-npm install @cirrobio/api-client@0.13.24 --save
+npm install @cirrobio/api-client@0.13.25 --save
 ```
 
 _unPublished (not recommended):_

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/api-client",
-  "version": "0.13.24",
+  "version": "0.13.25",
   "description": "API client for Cirro",
   "author": "CirroBio",
   "repository": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/sdk",
-  "version": "0.13.24",
+  "version": "0.13.25",
   "description": "SDK for Cirro",
   "author": "CirroBio",
   "repository": {


### PR DESCRIPTION
Bump version for new release so we can include the new sheets model updates in the API spec.