### PR TITLE
CI-671 (CI-1701) - Add environmentType to the run analysis request

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -22,7 +22,7 @@
         },
         "additionalProperties": {
           "npmName": "@cirrobio/api-client",
-          "npmVersion": "0.13.25",
+          "npmVersion": "0.13.26",
           "author": "CirroBio",
           "stringEnums": true,
           "supportsES6": true

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -36,7 +36,7 @@ navigate to the folder of your consuming project and run one of the following co
 _published:_
 
 ```
-npm install @cirrobio/api-client@0.13.25 --save
+npm install @cirrobio/api-client@0.13.26 --save
 ```
 
 _unPublished (not recommended):_

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/api-client",
-  "version": "0.13.25",
+  "version": "0.13.26",
   "description": "API client for Cirro",
   "author": "CirroBio",
   "repository": {

--- a/packages/api-client/src/models/RunAnalysisRequest.ts
+++ b/packages/api-client/src/models/RunAnalysisRequest.ts
@@ -13,6 +13,13 @@
  */
 
 import { mapValues } from '../runtime';
+import type { EnvironmentType } from './EnvironmentType';
+import {
+    EnvironmentTypeFromJSON,
+    EnvironmentTypeFromJSONTyped,
+    EnvironmentTypeToJSON,
+    EnvironmentTypeToJSONTyped,
+} from './EnvironmentType';
 import type { Tag } from './Tag';
 import {
     TagFromJSON,
@@ -88,12 +95,20 @@ export interface RunAnalysisRequest {
      */
     computeEnvironmentId?: string | null;
     /**
+     * The type of execution environment to run the workflow in, if not specified, the default for the pipeline is used
+     * @type {EnvironmentType}
+     * @memberof RunAnalysisRequest
+     */
+    environmentType?: EnvironmentType | null;
+    /**
      * List of tags to apply to the dataset
      * @type {Array<Tag>}
      * @memberof RunAnalysisRequest
      */
     tags?: Array<Tag> | null;
 }
+
+
 
 /**
  * Check if a given object implements the RunAnalysisRequest interface.
@@ -127,6 +142,7 @@ export function RunAnalysisRequestFromJSONTyped(json: any, ignoreDiscriminator: 
         'params': json['params'],
         'notificationEmails': json['notificationEmails'],
         'computeEnvironmentId': json['computeEnvironmentId'] == null ? undefined : json['computeEnvironmentId'],
+        'environmentType': json['environmentType'] == null ? undefined : EnvironmentTypeFromJSON(json['environmentType']),
         'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
     };
 }
@@ -152,6 +168,7 @@ export function RunAnalysisRequestToJSONTyped(value?: RunAnalysisRequest | null,
         'params': value['params'],
         'notificationEmails': value['notificationEmails'],
         'computeEnvironmentId': value['computeEnvironmentId'],
+        'environmentType': EnvironmentTypeToJSON(value['environmentType']),
         'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
     };
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cirrobio/sdk",
-  "version": "0.13.25",
+  "version": "0.13.26",
   "description": "SDK for Cirro",
   "author": "CirroBio",
   "repository": {


### PR DESCRIPTION
Regenerates the client for `RunAnalysisRequest.environmentType`, which lets a run request select its execution environment directly. Generated from the merged spec built locally, since the backend change is merged but not yet deployed to dev.

Patch bump to 0.13.26 on both packages: one new optional field, nothing removed, so the `^0.13.0` peer dependency is unchanged.
